### PR TITLE
Ensure Config is loaded before initializing ESX

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,14 +1,19 @@
-if Config.Framework.ESX_Legacy then 
-    ESX = exports[Config.Framework.ExtendedName]:getSharedObject()
-else
-    ESX = nil
-    Citizen.CreateThread(function()
+ESX = nil
+
+Citizen.CreateThread(function()
+    while Config == nil do
+        Citizen.Wait(0)
+    end
+
+    if Config.Framework.ESX_Legacy then
+        ESX = exports[Config.Framework.ExtendedName]:getSharedObject()
+    else
         while ESX == nil do
             TriggerEvent(Config.Framework.SharedEvent, function(obj) ESX = obj end)
             Citizen.Wait(500)
         end
-    end)
-end
+    end
+end)
 
 local IsDead = false
 local GarageOption = false


### PR DESCRIPTION
## Summary
- wait for the Config table to be available before accessing it on the client
- initialize ESX after the configuration has been loaded to avoid nil reference errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d06685a6448326a453f7aed174d9b3