### PR TITLE
Fix image source path for case rewards

### DIFF
--- a/case.lua
+++ b/case.lua
@@ -36,11 +36,16 @@ AddEventHandler("Open:Case", function(data)
 	end
 	local random = math.random(1,sum)
 	SetNuiFocus(true,true)
-	SendNUIMessage({
+        local imageSource = Config["image_source"]
+        if imageSource == nil or imageSource == "" then
+                imageSource = ("nui://%s/html/img/"):format(GetCurrentResourceName())
+        end
+
+        SendNUIMessage({
         type = "ui",
-		data = Config.Case[data].list,
-		img = Config["image_source"],
-		win = draw[random]
+                data = Config.Case[data].list,
+                img = imageSource,
+                win = draw[random]
     })
 	Wait(9000)
 	if draw[random].item then

--- a/config.lua
+++ b/config.lua
@@ -112,7 +112,8 @@ reduction = 0.75
 taxe = 100 * reduction
 
 ------------------------------------------------------------------------------------------------
-Config["image_source"] = "nui://boutiquev3/html/img/"
+-- Leave empty to automatically use the current resource name (nui://<resource>/html/img/)
+Config["image_source"] = ""
 
 Config.Chance = {
 	[1] = { name = "Common", rate = 50 }, -- tier 1


### PR DESCRIPTION
## Summary
- default the image source configuration to an empty value that will trigger auto-detection
- compute the NUI image path dynamically from the current resource name when opening cases

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d06d81a4ac8326afa01fd86cde4fe5